### PR TITLE
Add US Steel role and update future experience entry

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -149,9 +149,18 @@ const experiences = [
     description: "Leveraging my financial market expertise while transitioning in my Software Career to augment my income and keep myself busy. Started developing algorithmic trading strategies with high Sharpe Ratios to leverage my software development skills and automate my trading. Building proprietary indicators including the Fibonacci Moving Average, and educating new traders on Market Fundamentals through the Elite Trader Society community.",
   },
   {
+    date: "July 2025 - Present",
+    title: "Senior Applications Developer at US Steel",
+    description: "Joined US Steel as a Senior Applications Developer, working on the development and maintenance of internal applications and systems. Leveraging my IoT development background to help drive the future of Industry 4.0 initiatives within a live industrial production environment.",
+    link: {
+      text: "US Steel",
+      url: "https://www.ussteel.com/"
+    }
+  },
+  {
     date: "Future?",
-    title: "Working with YOU at YOUR Company",
-    description: "I am currently looking for opportunities to expand my skills and knowledge, potentially with you and your team. If you are interested in learning more about my skills and experience, please don't hesitate to contact me on LinkedIn.",
+    title: "Working on engaging side projects",
+    description: "I am always open to new opportunities to expand my skills and knowledge, collaborating with talented individuals, and contributing to meaningful projects. If you are interested in learning more about my skills and experience, please don't hesitate to contact me on LinkedIn or via my Email form below!",
     link: {
       text: "LinkedIn",
       url: "https://www.linkedin.com/in/michael-greene-ab59041b5/"


### PR DESCRIPTION
Added a new experience entry for Senior Applications Developer at US Steel, including a description and link. Updated the 'Future?' entry to reflect openness to new opportunities and revised the description and title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new experience entry for "Senior Applications Developer at US Steel" with details and a link to the company website.

* **Updates**
  * Updated the final experience entry to reflect ongoing side projects and revised the description to emphasize openness to new opportunities and collaboration, with contact options via LinkedIn and email.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->